### PR TITLE
Add openSUSE Leap 42.3

### DIFF
--- a/42.3/Dockerfile
+++ b/42.3/Dockerfile
@@ -1,0 +1,5 @@
+FROM moul/go-dl-extract
+MAINTAINER Manfred Touron <m@42.am> (@moul)
+# by inheriting the moul/go-dl-extract, the first RUN means a remote ADD
+RUN -md5 bb26f0044919c1cad903db33e9f60ee0 http://download.opensuse.org/ports/armv7hl/distribution/leap/42.3/appliances/openSUSE-Leap42.3-ARM-JeOS.armv7-rootfs.armv7l.tbz
+CMD ["/bin/bash"]


### PR DESCRIPTION
13.2 is obsolete. Server like workloads that require long term stability should mostly focus on openSUSE Leap.

I don't have experience with this toolchain, so I hope this is correct.